### PR TITLE
Added dockerfile and build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,22 @@ The fastest dork scanner written in Go.
 
 There are also various search engines supported by go-dork, including Google, Shodan, Bing, Duck, Yahoo and Ask.
 
-- [Install](#install)
-- [Usage](#usage)
-  - [Basic Usage](#basic-usage)
-  - [Flags](#flags)
-  - [Querying](#querying)
-  - [Defining engine](#defining-engine)
-  - [Pagination](#pagination)
-  - [Adding custom headers](#adding-headers)
-  - [Using proxy](#using-proxy)
-  - [Chained with other tools](#chained-with-other-tools)
-- [Supporting Materials](#supporting-materials)
-- [Help & Bugs](#help--bugs)
-- [TODOs](#todos)
-- [License](#license)
-- [Version](#version)
+- [go-dork](#go-dork)
+  - [Install](#install)
+    - [Docker option](#docker-option)
+  - [Usage](#usage)
+    - [Basic Usage](#basic-usage)
+    - [Flags](#flags)
+    - [Querying](#querying)
+    - [Defining engine](#defining-engine)
+    - [Pagination](#pagination)
+    - [Adding custom headers](#adding-custom-headers)
+    - [Using proxy](#using-proxy)
+    - [Chained with other tools](#chained-with-other-tools)
+  - [Supporting Materials](#supporting-materials)
+  - [Help \& Bugs](#help--bugs)
+  - [TODOs](#todos)
+  - [License](#license)
 
 ## Install
 
@@ -33,6 +34,18 @@ There are also various search engines supported by go-dork, including Google, Sh
 ```bash
 > GO111MODULE=on go install dw1.io/go-dork@latest
 ```
+
+### Docker option
+Clone the repository and build the image:
+```bash
+docker build -t go-dork .
+```
+
+Run the container:
+```bash
+docker run -it --rm go-dork -q "inurl:..."
+```
+
 
 ## Usage
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,21 @@
+# Builder image
+FROM golang:alpine AS builder
+
+
+WORKDIR /app
+
+# Install dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY *.go .
+
+# Build
+RUN go build -o /godork 
+
+# Runtime image
+FROM alpine AS app
+
+COPY --from=builder /godork /godork 
+
+ENTRYPOINT ["/godork"]


### PR DESCRIPTION
Hello! I love this tool. I'm always using it in my google hacking trainings. For me, it's more simple install as container. I'd created a dockerfile to build the application and manage as container.


If you want, we can create a repository in dockerhub to provide the builded container images and it would be easier for the docker users.

Regards!